### PR TITLE
Make training commands work

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -26,14 +26,14 @@ parser.add_argument('--dir_data', default='data/coco',
                     help='dir dataset to download or/and load images')
 parser.add_argument('--data_split', default='train', type=str,
                     help='Options: (default) train | val | test')
-parser.add_argument('--arch', '-a', default='resnet152',
+parser.add_argument('--arch', '-a', default='fbresnet152',
                     choices=convnets.model_names,
                     help='model architecture: ' +
                         ' | '.join(convnets.model_names) +
                         ' (default: fbresnet152)')
-parser.add_argument('--workers', default=4, type=int, 
+parser.add_argument('--workers', default=4, type=int,
                     help='number of data loading workers (default: 4)')
-parser.add_argument('--batch_size', '-b', default=80, type=int, 
+parser.add_argument('--batch_size', '-b', default=80, type=int,
                     help='mini-batch size (default: 80)')
 parser.add_argument('--mode', default='both', type=str,
                     help='Options: att | noatt | (default) both')
@@ -56,7 +56,7 @@ def main():
     if args.dataset == 'coco':
         if 'coco' not in args.dir_data:
             raise ValueError('"coco" string not in dir_data')
-        dataset = datasets.COCOImages(args.data_split, dict(dir=args.dir_data), 
+        dataset = datasets.COCOImages(args.data_split, dict(dir=args.dir_data),
             transform=transforms.Compose([
                 transforms.Scale(args.size),
                 transforms.CenterCrop(args.size),
@@ -68,7 +68,7 @@ def main():
             raise ValueError('train split is required for vgenome')
         if 'vgenome' not in args.dir_data:
             raise ValueError('"vgenome" string not in dir_data')
-        dataset = datasets.VisualGenomeImages(args.data_split, dict(dir=args.dir_data), 
+        dataset = datasets.VisualGenomeImages(args.data_split, dict(dir=args.dir_data),
             transform=transforms.Compose([
                 transforms.Scale(args.size),
                 transforms.CenterCrop(args.size),
@@ -122,7 +122,7 @@ def extract(data_loader, model, path_file, mode):
 
         nb_regions = output_att.size(2) * output_att.size(3)
         output_noatt = output_att.sum(3).sum(2).div(nb_regions).view(-1, 2048)
-        
+
         batch_size = output_att.size(0)
         if mode == 'both' or mode == 'att':
             hdf5_att[idx:idx+batch_size]   = output_att.data.cpu().numpy()
@@ -141,7 +141,7 @@ def extract(data_loader, model, path_file, mode):
                    i, len(data_loader),
                    batch_time=batch_time,
                    data_time=data_time,))
-            
+
     hdf5_file.close()
 
     # Saving image names in the same order than extraction

--- a/options/vqa/mutan_att_trainval.yaml
+++ b/options/vqa/mutan_att_trainval.yaml
@@ -12,8 +12,9 @@ vqa:
     samplingans: True
 coco:
     dir: data/coco
-    arch: fbresnet152torch
+    arch: fbresnet152
     mode: att
+    size: 448
 model:
     arch: MutanAtt
     dim_v: 2048

--- a/vqa/datasets/coco.py
+++ b/vqa/datasets/coco.py
@@ -23,18 +23,21 @@ class COCOImages(AbstractImagesDataset):
     def __init__(self, data_split, opt, transform=None, loader=default_loader):
         self.split_name = split_name(data_split)
         super(COCOImages, self).__init__(data_split, opt, transform, loader)
-        self.dir_split = os.path.join(self.dir_raw, self.split_name)
+        self.dir_split = self.get_dir_data()
         self.dataset = ImagesFolder(self.dir_split, transform=self.transform, loader=self.loader)
         self.name_to_index = self._load_name_to_index()
+
+    def get_dir_data(self):
+        return os.path.join(self.dir_raw, self.split_name)
 
     def _raw(self):
         if self.data_split in ['train', 'val']:
             os.system('wget http://msvocds.blob.core.windows.net/coco2014/{}.zip -P {}'.format(self.split_name, self.dir_raw))
         elif self.data_split == 'test':
-            os.execute('wget http://msvocds.blob.core.windows.net/coco2015/test2015.zip -P '+self.dir_raw)
+            os.system('wget http://msvocds.blob.core.windows.net/coco2015/test2015.zip -P '+self.dir_raw)
         else:
             assert False, 'data_split {} not exists'.format(self.data_split)
-        os.execute('unzip '+os.path.join(self.dir_raw, self.split_name+'.zip')+' -d '+self.dir_raw)
+        os.system('unzip '+os.path.join(self.dir_raw, self.split_name+'.zip')+' -d '+self.dir_raw)
 
     def _load_name_to_index(self):
         self.name_to_index = {name:index for index, name in enumerate(self.dataset.imgs)}

--- a/vqa/datasets/images.py
+++ b/vqa/datasets/images.py
@@ -38,7 +38,7 @@ class ImagesFolder(data.Dataset):
 
     def __getitem__(self, index):
         item = {}
-        item['name'] = self.imgs[index] 
+        item['name'] = self.imgs[index]
         item['path'] = os.path.join(self.root, item['name'])
         if self.loader is not None:
             item['visual']  = self.loader(item['path'])
@@ -57,10 +57,13 @@ class AbstractImagesDataset(data.Dataset):
         self.opt = opt
         self.transform = transform
         self.loader = loader
-
         self.dir_raw = os.path.join(self.opt['dir'], 'raw')
-        if not os.path.exists(self.dir_raw):
+
+        if not os.path.exists(self.get_dir_data()):
             self._raw()
+
+    def get_dir_data(self):
+        return self.dir_raw
 
     def get_by_name(self, image_name):
         index = self.name_to_index[image_name]


### PR DESCRIPTION
Fixes several issues so that the training commands in README work:

1. fix os.execute -> os.system
2. fix hacks for data_parallel. They weren't working in data parallel because the old lambda function refers to tensors not transferred to proper GPU yet.
3. fix train/val/test directory checking in COCO image loading. Current code only checks the containing dir of these split sets so it errors in cases when downloading val after train.
4. fix training config yaml missing size for coco, and thus can't find the correct directory to load data.